### PR TITLE
fix: include all columns in csv stats

### DIFF
--- a/src/couchdb/couchdb-admin.controller.spec.ts
+++ b/src/couchdb/couchdb-admin.controller.spec.ts
@@ -19,7 +19,7 @@ describe('CouchdbAdminController', () => {
     {
       name: 'test2.example.com',
       users: 5,
-      entities: { Child: { all: 30, active: 28 } },
+      entities: { Child: { all: 30, active: 28 }, School: { all: 2, active: 2 } },
     },
   ];
 
@@ -89,8 +89,16 @@ describe('CouchdbAdminController', () => {
       );
       expect(mockResponse.send).toHaveBeenCalledWith(
         expect.stringContaining(
-          'name,users,Child_all,Child_active,User_all,User_active',
+          'name,users,Child_all,Child_active,User_all,User_active,School_all,School_active',
         ),
+      );
+      // entity type only present in second row should still appear as column
+      expect(mockResponse.send).toHaveBeenCalledWith(
+        expect.stringContaining('0,0'), // School counts default to 0 for test1
+      );
+      // entity type only present in first row should have 0 values for second row
+      expect(mockResponse.send).toHaveBeenCalledWith(
+        expect.stringContaining('test2.example.com,5,30,28,0,0,2,2'),
       );
     });
 

--- a/src/couchdb/couchdb-admin.controller.spec.ts
+++ b/src/couchdb/couchdb-admin.controller.spec.ts
@@ -19,7 +19,10 @@ describe('CouchdbAdminController', () => {
     {
       name: 'test2.example.com',
       users: 5,
-      entities: { Child: { all: 30, active: 28 }, School: { all: 2, active: 2 } },
+      entities: {
+        Child: { all: 30, active: 28 },
+        School: { all: 2, active: 2 },
+      },
     },
   ];
 

--- a/src/couchdb/couchdb-admin.controller.ts
+++ b/src/couchdb/couchdb-admin.controller.ts
@@ -183,9 +183,17 @@ export class CouchdbAdminController {
       // replace statistics.entities (`{ Child: { all: 30, active: 25 }, User: { all: 5, active: 3 } }`)
       // and add flattened properties for each entity type and status to the statistics object
       // (e.g. `Child_all: 30, Child_active: 25, User_all: 5, User_active: 3`)
+      // Collect all unique entity types across all orgs first,
+      // so that every row has the same keys (Papa.unparse uses first row's keys to determine columns)
+      const allEntityTypes = new Set<string>();
+      statisticsData.forEach((stat) => {
+        Object.keys(stat.entities).forEach((type) => allEntityTypes.add(type));
+      });
+
       const flattenedData = statisticsData.map((stat) => {
-        const flattenedEntities = {};
-        for (const [entityType, counts] of Object.entries(stat.entities)) {
+        const flattenedEntities: Record<string, number> = {};
+        for (const entityType of allEntityTypes) {
+          const counts = stat.entities[entityType] ?? { all: 0, active: 0 };
           flattenedEntities[`${entityType}_all`] = counts.all;
           flattenedEntities[`${entityType}_active`] = counts.active;
         }


### PR DESCRIPTION
- fixes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV statistics export now produces consistent columns for all organizations; entity types absent for an organization are shown as zero counts instead of omitted.
* **Tests**
  * Updated test coverage to verify consistent CSV headers and that missing entity counts appear as 0,0 in exported rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->