### PR TITLE
chore: switch renovate schedule to Monday morning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended", "group:allNonMajor"],
   "enabledManagers": ["npm"],
   "timezone": "Etc/UTC",
-  "schedule": ["* 0-3 1 * *"],
+  "schedule": ["after 00:00 and before 09:00 on Monday"],
   "dependencyDashboard": true,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,


### PR DESCRIPTION
## Summary
- switch Renovate schedule to Monday morning window
- keep existing labels/reviewer behavior unchanged
- no Final Review label changes

## Validation
- config-only change in renovate.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the automated dependency update schedule to run on Monday mornings instead of the previous cron-based timing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aam-Digital/ndb-admin/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->